### PR TITLE
Refactor wth spread helper

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -41,6 +41,7 @@ import {
 	nativeBinOps,
 	unsignedLEB,
 	valType,
+	wat,
 } from "./compiler/wasm";
 import type { AST } from "./parser";
 import type { Expression, Statement } from "./syntax";
@@ -104,9 +105,7 @@ const _compile = (
 	resetFunctionBodies();
 
 	// WASM magic + version
-	const header = new Uint8Array([
-		0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
-	]);
+	const header = wat(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
 
 	// Function section
 	const mainFunc = mainFuncBody(ast, strings); // compiles
@@ -114,10 +113,10 @@ const _compile = (
 	const { functionTypes, functionIndices } = getFunctionTypes();
 	const funcSection = emitSection(
 		3,
-		new Uint8Array([
+		wat(
 			// loop over the defined functions and get their type indices
-			...unsignedLEB(definedFunctions.length + userDefinedFunctions.length),
-			...definedFunctions.flatMap((def) => {
+			unsignedLEB(definedFunctions.length + userDefinedFunctions.length),
+			definedFunctions.flatMap((def) => {
 				const key = getFunctionTypeKey(def.type);
 				const typeIndex = functionIndices.get(key);
 				if (typeIndex === undefined) {
@@ -125,7 +124,7 @@ const _compile = (
 				}
 				return unsignedLEB(typeIndex);
 			}),
-			...userDefinedFunctions.flatMap((func) => {
+			userDefinedFunctions.flatMap((func) => {
 				const key = getFunctionTypeKey(func.type);
 				const typeIndex = functionIndices.get(key);
 				if (typeIndex === undefined) {
@@ -135,24 +134,24 @@ const _compile = (
 				}
 				return unsignedLEB(typeIndex);
 			}),
-		]),
+		),
 	);
 
 	// Type section for all functions
 	const typeSection = emitSection(
 		1,
-		new Uint8Array([
-			...unsignedLEB(functionTypes.length), // number of types
-			...functionTypes.flat(), // all type entries defined at the top
-		]),
+		wat(
+			unsignedLEB(functionTypes.length), // number of types
+			functionTypes.flat(), // all type entries defined at the top
+		),
 	);
 
 	// Import section (import print/println from env)
 	const importSection = emitSection(
 		2,
-		new Uint8Array([
-			...unsignedLEB(importFunctions.length),
-			...importFunctions.flatMap((imp) => {
+		wat(
+			unsignedLEB(importFunctions.length),
+			importFunctions.flatMap((imp) => {
 				const key = getFunctionTypeKey(imp.type);
 				const typeIndex = functionIndices.get(key);
 				if (typeIndex === undefined) {
@@ -165,128 +164,128 @@ const _compile = (
 					...unsignedLEB(typeIndex),
 				];
 			}),
-		]),
+		),
 	);
 
 	// Memory section (1 memory with min 1 page)
 	const memorySection = emitSection(
 		5, // memory section id
-		new Uint8Array([
+		wat(
 			0x01, // number of memories
 			0x00, // limits: min only
 			0x10, // min = 1 page = 64KB
-		]),
+		),
 	);
 
 	// Export section (export "main" and "memory")
 	const exportSection = emitSection(
 		7,
-		new Uint8Array([
-			...unsignedLEB(2), // 2 exports
+		wat(
+			unsignedLEB(2), // 2 exports
 			// export "main" = function 1
-			...encodeString("main"),
+			encodeString("main"),
 			0x00, // export kind: func
 			// main is exported after imports (print/println)
-			...unsignedLEB(func().main),
+			unsignedLEB(func().main),
 			// export "memory" = memory 0
-			...encodeString("memory"),
+			encodeString("memory"),
 			0x02, // export kind: memory
 			0x00, // memory index 0
-		]),
+		),
 	);
 
 	// Code section
 	const codeSection = emitSection(
 		10,
-		new Uint8Array([
-			...unsignedLEB(Object.keys(functionBodies).length),
-			...definedFunctions.flatMap((def) => {
+		wat(
+			unsignedLEB(Object.keys(functionBodies).length),
+			definedFunctions.flatMap((def) => {
 				const body = functionBodies[def.name];
 				if (!body) throw new Error(`Function body for "${def.name}" not found`);
 				return [...unsignedLEB(body.length), ...body];
 			}),
-			...userDefinedFunctions.flatMap((func) => {
+			userDefinedFunctions.flatMap((func) => {
 				const body = functionBodies[func.name];
 				if (!body) {
 					throw new Error(`Function body for "${func.name}" not found`);
 				}
 				return [...unsignedLEB(body.length), ...body];
 			}),
-		]),
+		),
 	);
 
 	// Data section
 	const stringBytes = strings.getBytes();
 	const dataSection = emitSection(
 		11,
-		new Uint8Array([
+		wat(
 			0x01, // 1 data segment
 			0x00, // memory index 0
-			...i32.const(0), // start offset
-			...control.end(),
-			...unsignedLEB(stringBytes.length),
-			...stringBytes,
-		]),
+			i32.const(0), // start offset
+			control.end(),
+			unsignedLEB(stringBytes.length),
+			stringBytes,
+		),
 	);
 
 	// Keep at the end to set heap ptr from string length
 	const globalSection = emitSection(
 		6,
-		new Uint8Array([
+		wat(
 			0x01, // one global
 			valType("i32"),
 			0x01, // mutable
-			...i32.const(stringBytes.length + 1), // TODO: do I need to grow this?
-			...control.end(), // end of global init
-		]),
+			i32.const(stringBytes.length + 1), // TODO: do I need to grow this?
+			control.end(), // end of global init
+		),
 	);
 
-	return new Uint8Array([
-		...header,
-		...typeSection,
-		...importSection,
-		...funcSection,
-		...memorySection,
-		...globalSection,
-		...exportSection,
-		...codeSection,
-		...dataSection,
-	]);
+	return wat(
+		header,
+		typeSection,
+		importSection,
+		funcSection,
+		memorySection,
+		globalSection,
+		exportSection,
+		codeSection,
+		dataSection,
+	);
 };
 
 export const mainFuncBody = (
 	ast: AST,
 	strings: ReturnType<typeof createStringTable>,
-): number[] => {
-	const instructions: number[] = compileStatements(ast.body, strings);
+): Uint8Array => {
+	const instructions: Uint8Array = compileStatements(ast.body, strings);
 	// Since we are boxing, there's only one type of local variable (i32)
-	return [...getLocalDecls(), ...instructions, ...control.end()];
+	return wat(getLocalDecls(), instructions, control.end());
 };
 
 const compileStatements = (
 	statements: Statement[],
 	strings: ReturnType<typeof createStringTable>,
-): number[] => {
-	const instructions: number[] = [];
+): Uint8Array => {
+	const instructions: Uint8Array[] = [];
 	for (const stmt of statements) {
 		const bytes = compileStatement(stmt, strings);
-		instructions.push(...bytes);
+		instructions.push(bytes);
 	}
-	return instructions;
+	return wat(...instructions);
 };
 
 const compileStatement = (
 	stmt: Statement,
 	strings: ReturnType<typeof createStringTable>,
-): number[] => {
+): Uint8Array => {
 	switch (stmt.type) {
 		case "PrintlnStatement": {
 			const bytes = compileExpression(stmt.expression, strings);
-			return [...bytes, ...fn.call(func().println)];
+			return wat(bytes, fn.call(func().println));
 		}
 		case "PrintStatement": {
 			const bytes = compileExpression(stmt.expression, strings);
-			return [...bytes, ...fn.call(func().print)];
+			return wat(bytes, fn.call(func().print));
 		}
 		case "LocalAssignStatement":
 		case "AssignStatement": {
@@ -302,20 +301,20 @@ const compileStatement = (
 					identifier.name.length,
 				);
 			}
-			return [...bytes, ...local.set(varInfo.index)]; // set the variable
+			return wat(bytes, local.set(varInfo.index)); // set the variable
 		}
 		case "IfStatement": {
 			const condition = compileExpression(stmt.condition, strings);
 			enterScope();
 			const thenBranch = compileStatements(stmt.thenBranch, strings);
 			exitScope();
-			const bytes = [
-				...condition,
-				...fn.call(func().is_truthy),
-				...if_.start(),
-				...thenBranch,
-			];
-			let elseBlock: number[] = [];
+			const bytes = wat(
+				condition,
+				fn.call(func().is_truthy),
+				if_.start(),
+				thenBranch,
+			);
+			let elseBlock: Uint8Array = wat();
 			if (stmt.elseBranch) {
 				enterScope();
 				elseBlock = compileStatements(stmt.elseBranch, strings);
@@ -329,19 +328,19 @@ const compileStatement = (
 					enterScope();
 					const elifBranch = compileStatements(elif.body, strings);
 					exitScope();
-					elseBlock = [
-						...condition,
-						...fn.call(func().is_truthy),
-						...if_.start(),
-						...elifBranch,
-						...if_.else(),
-						...elseBlock, // else block needs to be repositioned
-						...if_.end(),
-					];
+					elseBlock = wat(
+						condition,
+						fn.call(func().is_truthy),
+						if_.start(),
+						elifBranch,
+						if_.else(),
+						elseBlock,
+						if_.end(),
+					);
 				}
 			}
 			// Add the final elseBlock to the original if
-			return [...bytes, ...if_.else(), ...elseBlock, ...if_.end()];
+			return wat(...bytes, if_.else(), elseBlock, if_.end());
 		}
 		case "WhileStatement": {
 			enterScope();
@@ -354,34 +353,34 @@ const compileStatement = (
 			const counterIndex = consumeScratchIndex();
 
 			// biome-ignore format: keep loop structure
-			return [
-				// Start counter at 0
-				...i32.const(0),
-				...local.set(counterIndex),
-				...block.start(),
-                ...loop.start(),
+			return wat(
+                // Start counter at 0
+                i32.const(0),
+                local.set(counterIndex),
+                block.start(),
+                loop.start(),
                     // check if we reached max iterations
-                    ...local.get(counterIndex),
-                    ...i32.const(MAX_ITERATIONS),
-                    ...i32.ge_u(),
-                    ...if_.start(), // counter >= maxIters
-                        ...misc.unreachable(), // infinite loop, throw error
-                    ...if_.end(),
-                    ...local.get(counterIndex),
-                    ...i32.const(1),
-                    ...i32.add(), // increment counter
-                    ...local.set(counterIndex),
+                    local.get(counterIndex),
+                    i32.const(MAX_ITERATIONS),
+                    i32.ge_u(),
+                    if_.start(), // counter >= maxIters
+                        misc.unreachable(), // infinite loop, throw error
+                    if_.end(),
+                    local.get(counterIndex),
+                    i32.const(1),
+                    i32.add(), // increment counter
+                    local.set(counterIndex),
 
-                    ...condition,
-                    ...fn.call(func().is_truthy),
-                    ...i32.eqz(), // check if condition is false
-                    ...loop.br_if(1), // break out of outer block
+                    condition,
+                    fn.call(func().is_truthy),
+                    i32.eqz(), // check if condition is false
+                    loop.br_if(1), // break out of outer block
 
-                    ...body,
-				    ...loop.br(0), // loop back
-				...loop.end(),
-				...block.end(),
-			];
+                    body,
+                    loop.br(0), // loop back
+                loop.end(),
+                block.end(),
+            );
 		}
 		case "ForStatement": {
 			const { assignment, condition, increment, body } = stmt;
@@ -407,63 +406,63 @@ const compileStatement = (
 			const isDescending = consumeScratchIndex();
 			const counterIndex = consumeScratchIndex();
 			// biome-ignore format: keep loop structure
-			return [
-				// Start counter at 0
-				...i32.const(0),
-				...local.set(counterIndex),
+			return wat(
+                // Start counter at 0
+                i32.const(0),
+                local.set(counterIndex),
 
-				...init, // e.g. i := 0
-				...step,
-				...fn.call(func().unbox_number),
-				...f64.const(0),
-				...f64.lt(), // step < 0 ?
-				...local.set(isDescending),
+                init, // e.g. i := 0
+                step,
+                fn.call(func().unbox_number),
+                f64.const(0),
+                f64.lt(), // step < 0 ?
+                local.set(isDescending),
 
-				...block.start(),
-				...loop.start(),
+                block.start(),
+                loop.start(),
                     // check if we reached max iterations
-                    ...local.get(counterIndex),
-                    ...i32.const(MAX_ITERATIONS),
-                    ...i32.ge_u(),
-                    ...if_.start(), // counter >= maxIters
-                        ...misc.unreachable(), // infinite loop, throw error
-                    ...if_.end(),
-                    ...local.get(counterIndex),
-                    ...i32.const(1),
-                    ...i32.add(), // increment counter
-                    ...local.set(counterIndex),
+                    local.get(counterIndex),
+                    i32.const(MAX_ITERATIONS),
+                    i32.ge_u(),
+                    if_.start(), // counter >= maxIters
+                        misc.unreachable(), // infinite loop, throw error
+                    if_.end(),
+                    local.get(counterIndex),
+                    i32.const(1),
+                    i32.add(), // increment counter
+                    local.set(counterIndex),
 
-                    ...local.get(isDescending),
-                    ...if_.start(valType("i32")), // descending case
-                        ...local.get(loopVar.index),
-                        ...fn.call(func().unbox_number),
-                        ...cond,
-                        ...fn.call(func().unbox_number),
-                        ...f64.lt(), // i < cond ? 1 : 0
-                    ...if_.else(), // ascending case
-                        ...local.get(loopVar.index),
-                        ...fn.call(func().unbox_number),
-                        ...cond,
-                        ...fn.call(func().unbox_number),
-                        ...f64.gt(), // i > cond ? 1 : 0
-                    ...if_.end(),
-                    ...loop.br_if(1), // exit if 1
+                    local.get(isDescending),
+                    if_.start(valType("i32")), // descending case
+                        local.get(loopVar.index),
+                        fn.call(func().unbox_number),
+                        cond,
+                        fn.call(func().unbox_number),
+                        f64.lt(), // i < cond ? 1 : 0
+                    if_.else(), // ascending case
+                        local.get(loopVar.index),
+                        fn.call(func().unbox_number),
+                        cond,
+                        fn.call(func().unbox_number),
+                        f64.gt(), // i > cond ? 1 : 0
+                    if_.end(),
+                    loop.br_if(1), // exit if 1
 
-                    ...loopBody,
+                    loopBody,
 
                     // increment the loop variable
-                    ...local.get(loopVar.index),
-                    ...fn.call(func().unbox_number),
-                    ...step,
-                    ...fn.call(func().unbox_number),
-                    ...f64.add(),
-                    ...fn.call(func().box_number),
-                    ...local.set(loopVar.index),
+                    local.get(loopVar.index),
+                    fn.call(func().unbox_number),
+                    step,
+                    fn.call(func().unbox_number),
+                    f64.add(),
+                    fn.call(func().box_number),
+                    local.set(loopVar.index),
 
-                    ...loop.br(0), // loop back
-				...loop.end(),
-				...block.end(),
-			];
+                    loop.br(0), // loop back
+                loop.end(),
+                block.end(),
+            );
 		}
 		case "FunctionDeclStatement": {
 			const { name, params, body } = stmt;
@@ -492,15 +491,11 @@ const compileStatement = (
 			const localDecls = getLocalDecls();
 			setLocalVarsIndex(prevIndex); // restore local vars index
 			setScopes(scopesTmp); // restore scopes
-			addFunctionBody(name.name, [
-				...localDecls,
-				...bodyBytes,
-				...control.end(),
-			]);
-			return [];
+			addFunctionBody(name.name, wat(localDecls, bodyBytes, control.end()));
+			return wat();
 		}
 		case "ReturnStatement": {
-			return [...compileExpression(stmt.expression, strings), ...fn.return()];
+			return wat(compileExpression(stmt.expression, strings), fn.return());
 		}
 		case "ExpressionStatement": {
 			// check if the expression is a function call
@@ -508,9 +503,9 @@ const compileStatement = (
 			if (stmt.expression.type === "FunctionCallExpression") {
 				const code = compileExpression(stmt.expression, strings);
 				const returns = getFunctionReturnCount(stmt.expression.name.name);
-				return returns > 0 ? [...code, ...misc.drop()] : code;
+				return returns > 0 ? wat(code, misc.drop()) : code;
 			}
-			return [...compileExpression(stmt.expression, strings), ...misc.drop()];
+			return wat(compileExpression(stmt.expression, strings), misc.drop());
 		}
 		default:
 			throw new Error("Something went wrong");
@@ -521,23 +516,23 @@ const comparisonOps = new Set(["==", "~=", ">", ">=", "<", "<="]);
 const compileExpression = (
 	expr: Expression,
 	strings: ReturnType<typeof createStringTable>,
-): number[] => {
+): Uint8Array => {
 	const textEncoder = new TextEncoder();
 	switch (expr.type) {
 		case "StringLiteral": {
 			const offset = strings.getOffset(String(expr.value));
 			const length = textEncoder.encode(String(expr.value)).length;
-			return [
-				...i32.const(offset),
-				...i32.const(length),
-				...fn.call(func().box_string),
-			];
+			return wat(
+				i32.const(offset),
+				i32.const(length),
+				fn.call(func().box_string),
+			);
 		}
 		case "NumberLiteral": {
-			return [...f64.const(expr.value), ...fn.call(func().box_number)];
+			return wat(f64.const(expr.value), fn.call(func().box_number));
 		}
 		case "BooleanLiteral":
-			return [...i32.const(expr.value ? 1 : 0), ...fn.call(func().box_bool)];
+			return wat(i32.const(expr.value ? 1 : 0), fn.call(func().box_bool));
 		case "Identifier": {
 			const variable = getVar(expr.name);
 			if (!variable) {
@@ -549,7 +544,7 @@ const compileExpression = (
 				);
 			}
 			// All vars are boxed i32, so just get the pointer
-			return local.get(variable.index);
+			return wat(local.get(variable.index));
 		}
 		case "GroupingExpression":
 			return compileExpression(expr.expression, strings);
@@ -560,41 +555,41 @@ const compileExpression = (
 			// Special handling of + for string concatenation
 			if (nativeOp && expr.operator === "+") {
 				// biome-ignore format: keep if structure
-				return [
-					...left,
-					...fn.call(func().is_string),
-					...right,
-					...fn.call(func().is_string),
-					...i32.or(), // is_string(left) || is_string(right)
-					...if_.start(valType("i32")),
-                        ...left,
-                        ...right,
-                        ...fn.call(func().concat),
-					...if_.else(),
-                        ...left,
-                        ...fn.call(func().is_bool),
-                        ...right,
-                        ...fn.call(func().is_bool),
-                        ...i32.or(),
-                        ...if_.start(valType("i32")), // is_bool(left) || is_bool(right)
-                            ...left,
-                            ...fn.call(func().to_number),
-                            ...fn.call(func().unbox_number),
-                            ...right,
-                            ...fn.call(func().to_number),
-                            ...fn.call(func().unbox_number),
-                            ...f64.add(),
-                            ...fn.call(func().box_number),
-                        ...if_.else(), // just add them otherwise
-                            ...left,
-                            ...fn.call(func().unbox_number),
-                            ...right,
-                            ...fn.call(func().unbox_number),
-                            ...f64.add(),
-                            ...fn.call(func().box_number),
-                        ...if_.end(), // bool
-                    ...if_.end(), // string
-	            ];
+				return wat(
+                    left,
+                    fn.call(func().is_string),
+                    right,
+                    fn.call(func().is_string),
+                    i32.or(), // is_string(left) || is_string(right)
+                    if_.start(valType("i32")),
+                        left,
+                        right,
+                        fn.call(func().concat),
+                    if_.else(),
+                        left,
+                        fn.call(func().is_bool),
+                        right,
+                        fn.call(func().is_bool),
+                        i32.or(),
+                        if_.start(valType("i32")), // is_bool(left) || is_bool(right)
+                            left,
+                            fn.call(func().to_number),
+                            fn.call(func().unbox_number),
+                            right,
+                            fn.call(func().to_number),
+                            fn.call(func().unbox_number),
+                            f64.add(),
+                            fn.call(func().box_number),
+                        if_.else(), // just add them otherwise
+                            left,
+                            fn.call(func().unbox_number),
+                            right,
+                            fn.call(func().unbox_number),
+                            f64.add(),
+                            fn.call(func().box_number),
+                        if_.end(), // bool
+                    if_.end(), // string
+                );
 			}
 
 			// Native operators supported for f64
@@ -609,60 +604,60 @@ const compileExpression = (
 				// comparing f64, f64 results in i32 so convert it back to f64
 				if (comparisonOps.has(expr.operator)) {
 					ops.push(...fn.call(func().box_bool));
-					return ops;
+					return wat(ops);
 				}
 				ops.push(...fn.call(func().box_number));
-				return ops;
+				return wat(ops);
 			}
 			switch (expr.operator) {
 				case "%":
-					return [
-						...left,
-						...fn.call(func().unbox_number),
-						...right,
-						...fn.call(func().unbox_number),
-						...fn.call(func().mod), // call mod -> f64
-						...fn.call(func().box_number), // box the result
-					];
+					return wat(
+						left,
+						fn.call(func().unbox_number),
+						right,
+						fn.call(func().unbox_number),
+						fn.call(func().mod), // call mod -> f64
+						fn.call(func().box_number), // box the result
+					);
 				case "^":
 					// TODO write runtime error if exp is not an integer
-					return [
-						...left,
-						...fn.call(func().unbox_number),
-						...right,
-						...fn.call(func().unbox_number),
-						...fn.call(func().math_pow),
-						...fn.call(func().box_number),
-					];
+					return wat(
+						left,
+						fn.call(func().unbox_number),
+						right,
+						fn.call(func().unbox_number),
+						fn.call(func().math_pow),
+						fn.call(func().box_number),
+					);
 				case "and": {
 					const scratch = consumeScratchIndex();
 					// biome-ignore format: keep if structure
-					return [
-						...left, // evaluate A
-						...local.set(scratch),
-						...local.get(scratch),
-						...fn.call(func().is_truthy),
-						...if_.start(valType("i32")),
-						    ...right, // evaluate and return B
-						...if_.else(),
-						    ...local.get(scratch), // return A
-						...if_.end(),
-					];
+					return wat(
+                        left, // evaluate A
+                        local.set(scratch),
+                        local.get(scratch),
+                        fn.call(func().is_truthy),
+                        if_.start(valType("i32")),
+                            right, // evaluate and return B
+                        if_.else(),
+                            local.get(scratch), // return A
+                        if_.end(),
+                    );
 				}
 				case "or": {
 					const scratch = consumeScratchIndex();
 					// biome-ignore format: keep if structure
-					return [
-						...left, // evaluate A
-						...local.set(scratch),
-						...local.get(scratch),
-						...fn.call(func().is_truthy),
-						...if_.start(valType("i32")),
-						    ...local.get(scratch), //return A
-						...if_.else(),
-						    ...right, // evaluate and return B
-						...if_.end(),
-					];
+					return wat(
+                        left, // evaluate A
+                        local.set(scratch),
+                        local.get(scratch),
+                        fn.call(func().is_truthy),
+                        if_.start(valType("i32")),
+                            local.get(scratch), //return A
+                        if_.else(),
+                            right, // evaluate and return B
+                        if_.end(),
+                    );
 				}
 				default:
 					throw new Error(`Unsupported binary operator: ${expr.operator}`);
@@ -674,26 +669,26 @@ const compileExpression = (
 					return compileExpression(expr.argument, strings);
 				case "-": {
 					if (expr.argument.type === "NumberLiteral") {
-						return [
-							...f64.const(-expr.argument.value), // note the "-"
-							...fn.call(func().box_number),
-						];
+						return wat(
+							f64.const(-expr.argument.value), // note the "-"
+							fn.call(func().box_number),
+						);
 					}
-					return [
-						...compileExpression(expr.argument, strings),
-						...fn.call(func().unbox_number),
-						...f64.neg(),
-						...fn.call(func().box_number),
-					];
+					return wat(
+						compileExpression(expr.argument, strings),
+						fn.call(func().unbox_number),
+						f64.neg(),
+						fn.call(func().box_number),
+					);
 				}
 				case "~":
-					return [
-						...compileExpression(expr.argument, strings),
-						...fn.call(func().unbox_number),
-						...f64.const(0),
-						...f64.eq(), // result is i32 here
-						...fn.call(func().box_bool),
-					];
+					return wat(
+						compileExpression(expr.argument, strings),
+						fn.call(func().unbox_number),
+						f64.const(0),
+						f64.eq(), // result is i32 here
+						fn.call(func().box_bool),
+					);
 				default:
 					throw new Error(`Unsupported unary operator: ${expr.operator}`);
 			}
@@ -709,11 +704,11 @@ const compileExpression = (
 						name.name.length,
 					);
 				}
-				return [
+				return wat(
 					...args.flatMap((arg) => compileExpression(arg, strings)),
-					...fn.call(func().is_string), // returns boxed bool
-					...fn.call(func().box_bool),
-				];
+					fn.call(func().is_string), // returns boxed bool
+					fn.call(func().box_bool),
+				);
 			}
 			if (!f) {
 				throw new CompilerError(
@@ -731,10 +726,10 @@ const compileExpression = (
 					name.name.length,
 				);
 			}
-			return [
+			return wat(
 				...args.flatMap((arg) => compileExpression(arg, strings)),
-				...fn.call(func()[name.name]),
-			];
+				fn.call(func()[name.name]),
+			);
 		}
 		default:
 			throw new Error("Something went wrong");

--- a/src/compiler/functions.ts
+++ b/src/compiler/functions.ts
@@ -11,6 +11,7 @@ import {
 	misc,
 	unsignedLEB,
 	valType,
+	wat,
 } from "./wasm";
 
 // Set up function signatures
@@ -118,403 +119,403 @@ export const getFunctionReturnCount = (name: string): number => {
 };
 
 // js/lua style modulus
-const modFunctionBody = [
-	...local.declare(),
-	...local.get(0), // 0 (left)
-	...local.get(1), // 1 (right)
-	...local.get(0), // 0 (left)
-	...local.get(1), // 1 (right)
-	...f64.div(),
-	...f64.trunc(), // trunc to integer
-	...f64.mul(), // multiply by right
-	...f64.sub(), // subtract -> yields a - b * floor(a/b)
-	...fn.end(),
-];
+const modFunctionBody = wat(
+	local.declare(),
+	local.get(0), // 0 (left)
+	local.get(1), // 1 (right)
+	local.get(0), // 0 (left)
+	local.get(1), // 1 (right)
+	f64.div(),
+	f64.trunc(), // trunc to integer
+	f64.mul(), // multiply by right
+	f64.sub(), // subtract -> yields a - b * floor(a/b)
+	fn.end(),
+);
 
-const isStringFunctionBody: number[] = [
+const isStringFunctionBody = wat(
 	// param: pointer to the boxed value
-	...local.declare(),
-	...local.get(0),
-	...i32.load(0),
-	...i32.const(2), // is it tag 2 (string)?
-	...i32.eq(),
-	...fn.end(),
-];
+	local.declare(),
+	local.get(0),
+	i32.load(0),
+	i32.const(2), // is it tag 2 (string)?
+	i32.eq(),
+	fn.end(),
+);
 
-const isBooleanFunctionBody: number[] = [
+const isBooleanFunctionBody = wat(
 	// param: pointer to the boxed value
-	...local.declare(),
-	...local.get(0),
-	...i32.load(0),
-	...i32.const(3), // is it tag 3 (boolean)?
-	...i32.eq(),
-	...fn.end(),
-];
+	local.declare(),
+	local.get(0),
+	i32.load(0),
+	i32.const(3), // is it tag 3 (boolean)?
+	i32.eq(),
+	fn.end(),
+);
 
 // biome-ignore format: keep loop structure
-const memoryCopyFunctionBody: number[] = [
-	// params: from (0), to (1), len (2)
-	...local.declare("i32", "i32"), // i, current byte
-	...i32.const(0), // i = 0
-	...local.set(3),
+const memoryCopyFunctionBody = wat(
+    // params: from (0), to (1), len (2)
+    local.declare("i32", "i32"), // i, current byte
+    i32.const(0), // i = 0
+    local.set(3),
 
-	...block.start(),
-	...loop.start(),
-        ...local.get(3),
-        ...local.get(2),
-        ...i32.ge_s(), // i >= len ?
-        ...loop.br_if(1),
+    block.start(),
+    loop.start(),
+        local.get(3),
+        local.get(2),
+        i32.ge_s(), // i >= len ?
+        loop.br_if(1),
 
-        ...local.get(0),
-        ...local.get(3),
-        ...i32.add(),
-        ...i32.load8_u(), // ptr @ from + i
-        ...local.set(4), // current byte
+        local.get(0),
+        local.get(3),
+        i32.add(),
+        i32.load8_u(), // ptr @ from + i
+        local.set(4), // current byte
 
-        ...local.get(1),
-        ...local.get(3),
-        ...i32.add(),
-        ...local.get(4), // current byte
-        ...i32.store8(), // ptr @ to + i
+        local.get(1),
+        local.get(3),
+        i32.add(),
+        local.get(4), // current byte
+        i32.store8(), // ptr @ to + i
 
-        ...local.get(3),
-        ...i32.const(1),
-        ...i32.add(),
-        ...local.set(3), // i++
+        local.get(3),
+        i32.const(1),
+        i32.add(),
+        local.set(3), // i++
 
-        ...loop.br(0), // loop back
-	...loop.end(),
-	...block.end(),
-	...fn.end(),
-];
+        loop.br(0), // loop back
+    loop.end(),
+    block.end(),
+    fn.end(),
+);
 
-const concatFunctionBody: number[] = [
+const concatFunctionBody = wat(
 	// incoming params: left (0), right (1) - i32 boxed unknowns
-	...local.declare("i32", "i32", "i32", "i32", "i32"),
+	local.declare("i32", "i32", "i32", "i32", "i32"),
 
-	...i32.const(16),
-	...fn.call(func().ensure_space),
+	i32.const(16),
+	fn.call(func().ensure_space),
 
 	// 0 = left
-	...local.get(0),
-	...fn.call(func().to_string), // JS import
-	...local.set(0),
+	local.get(0),
+	fn.call(func().to_string), // JS import
+	local.set(0),
 
 	// 1 = right
-	...local.get(1),
-	...fn.call(func().to_string),
-	...local.set(1),
+	local.get(1),
+	fn.call(func().to_string),
+	local.set(1),
 
 	// 2 = leftOffset
-	...local.get(0),
-	...i32.const(4),
-	...i32.add(),
-	...i32.load(),
-	...local.set(2),
+	local.get(0),
+	i32.const(4),
+	i32.add(),
+	i32.load(),
+	local.set(2),
 
 	// 3 = leftLength
-	...local.get(0),
-	...i32.const(8),
-	...i32.add(),
-	...i32.load(),
-	...local.set(3),
+	local.get(0),
+	i32.const(8),
+	i32.add(),
+	i32.load(),
+	local.set(3),
 
 	// 4 = rightOffset
-	...local.get(1),
-	...i32.const(4),
-	...i32.add(),
-	...i32.load(),
-	...local.set(4),
+	local.get(1),
+	i32.const(4),
+	i32.add(),
+	i32.load(),
+	local.set(4),
 
 	// 5 = rightLength
-	...local.get(1),
-	...i32.const(8),
-	...i32.add(),
-	...i32.load(),
-	...local.set(5),
+	local.get(1),
+	i32.const(8),
+	i32.add(),
+	i32.load(),
+	local.set(5),
 
 	// 6 = resultOffset
-	...global.get(0), // global heap ptr
-	...local.set(6),
+	global.get(0), // global heap ptr
+	local.set(6),
 
 	// copy left
-	...local.get(2), // left offset (from)
-	...local.get(6), // end of heap (to)
-	...local.get(3), // left length (len)
-	...fn.call(func().memory_copy),
+	local.get(2), // left offset (from)
+	local.get(6), // end of heap (to)
+	local.get(3), // left length (len)
+	fn.call(func().memory_copy),
 
 	// copy right
-	...local.get(4), // right offset (from)
-	...local.get(6), // end of heap before left
-	...local.get(3), // left length
-	...i32.add(), // get new end of heap (to)
-	...local.get(5), // right length (len)
-	...fn.call(func().memory_copy),
+	local.get(4), // right offset (from)
+	local.get(6), // end of heap before left
+	local.get(3), // left length
+	i32.add(), // get new end of heap (to)
+	local.get(5), // right length (len)
+	fn.call(func().memory_copy),
 
 	// update heap pointer
-	...global.get(0),
-	...local.get(3),
-	...local.get(5),
-	...i32.add(),
-	...i32.add(),
-	...global.set(0),
+	global.get(0),
+	local.get(3),
+	local.get(5),
+	i32.add(),
+	i32.add(),
+	global.set(0),
 
 	// return new string
-	...local.get(6),
-	...local.get(3),
-	...local.get(5),
-	...i32.add(),
-	...fn.call(func().box_string),
+	local.get(6),
+	local.get(3),
+	local.get(5),
+	i32.add(),
+	fn.call(func().box_string),
 
-	...fn.end(),
-];
+	fn.end(),
+);
 
 // biome-ignore format: keep if structure
-const toNumberFunctionBody: number[] = [
-	// incoming param: a pointer to a boxed value
-	...local.declare(),
-	...local.get(0),
-	...i32.load(0), // load tag
+const toNumberFunctionBody = wat(
+    // incoming param: a pointer to a boxed value
+    local.declare(),
+    local.get(0),
+    i32.load(0), // load tag
 
-	...i32.const(1),
-	...i32.eq(),
-	// tag == 1 (number)?
-	...if_.start(valType("f64")),
-        ...local.get(0),
-        ...i32.const(8),
-        ...i32.add(),
-        ...f64.load(0),
-	...if_.else(),
-        ...local.get(0),
-        ...i32.load(0), // reload tag
-        ...i32.const(3),
-        ...i32.eq(),
+    i32.const(1),
+    i32.eq(),
+    // tag == 1 (number)?
+    if_.start(valType("f64")),
+        local.get(0),
+        i32.const(8),
+        i32.add(),
+        f64.load(0),
+    if_.else(),
+        local.get(0),
+        i32.load(0), // reload tag
+        i32.const(3),
+        i32.eq(),
         // tag == 3 (bool)?
-        ...if_.start(valType("f64")),
-            ...local.get(0),
-            ...i32.const(4),
-            ...i32.add(),
-            ...i32.load(0),
-            ...f64.convert_i32_s(),
-        ...if_.else(),
-            ...local.get(0),
-            ...i32.load(0), // reload tag
-            ...i32.const(2),
-            ...i32.eq(),
+        if_.start(valType("f64")),
+            local.get(0),
+            i32.const(4),
+            i32.add(),
+            i32.load(0),
+            f64.convert_i32_s(),
+        if_.else(),
+            local.get(0),
+            i32.load(0), // reload tag
+            i32.const(2),
+            i32.eq(),
             // tag == 2 (string)?
-            ...if_.start(valType("f64")),
+            if_.start(valType("f64")),
                 // strings → NaN
-                ...f64.const(Number.NaN),
-            ...if_.else(),
+                f64.const(Number.NaN),
+            if_.else(),
                 // tag == 0 (null)
-                ...f64.const(0),
-	        ...if_.end(), // string
-	    ...if_.end(), // bool
-	...if_.end(), // number
-	...fn.call(func().box_number),
-	...fn.end(),
-];
+                f64.const(0),
+            if_.end(), // string
+        if_.end(), // bool
+    if_.end(), // number
+    fn.call(func().box_number),
+    fn.end(),
+);
 
 // biome-ignore format: keep if structure
-const isTruthyFunctionBody: number[] = [
-	// incoming param: a pointer to a boxed value
-	...local.declare(),
-	...local.get(0), // load tag
-	...i32.load(0),
+const isTruthyFunctionBody = wat(
+    // incoming param: a pointer to a boxed value
+    local.declare(),
+    local.get(0), // load tag
+    i32.load(0),
 
-	// if tag == 1 (number)
-	...i32.const(1),
-	...i32.eq(),
-	...if_.start(valType("i32")), // if (result i32)
-        ...local.get(0),
-        ...i32.const(8),
-        ...i32.add(), // offset + 8
-        ...f64.load(0),
-        ...f64.const(0),
-        ...f64.ne(), // (number != 0)
-	...if_.else(),
-        ...local.get(0),
-        ...i32.load(0), // load tag again
+    // if tag == 1 (number)
+    i32.const(1),
+    i32.eq(),
+    if_.start(valType("i32")), // if (result i32)
+        local.get(0),
+        i32.const(8),
+        i32.add(), // offset + 8
+        f64.load(0),
+        f64.const(0),
+        f64.ne(), // (number != 0)
+    if_.else(),
+        local.get(0),
+        i32.load(0), // load tag again
         // if tag == 3 (bool)
-        ...i32.const(3),
-        ...i32.eq(),
-        ...if_.start(valType("i32")), // if (result i32)
-            ...local.get(0),
-            ...i32.const(4),
-            ...i32.add(), // offset + 4
-            ...i32.load(0),
-        ...if_.else(),
-            ...local.get(0),
-            ...i32.load(0), // load tag again
-            ...i32.const(2),
-            ...i32.eq(),
-            ...if_.start(valType("i32")), // if (result i32)
-                ...local.get(0),
-                ...i32.const(8),
-                ...i32.add(),
-                ...i32.load(0),
-                ...i32.const(0),
-                ...i32.ne(), // (length > 0)
-	        ...if_.else(),
+        i32.const(3),
+        i32.eq(),
+        if_.start(valType("i32")), // if (result i32)
+            local.get(0),
+            i32.const(4),
+            i32.add(), // offset + 4
+            i32.load(0),
+        if_.else(),
+            local.get(0),
+            i32.load(0), // load tag again
+            i32.const(2),
+            i32.eq(),
+            if_.start(valType("i32")), // if (result i32)
+                local.get(0),
+                i32.const(8),
+                i32.add(),
+                i32.load(0),
+                i32.const(0),
+                i32.ne(), // (length > 0)
+            if_.else(),
                 // falsy fallback
-                ...i32.const(0), // return 0 (falsy)
-	        ...if_.end(), // end string
-	    ...if_.end(), // end bool
-	...if_.end(), // end number
-	...fn.end(),
-];
+                i32.const(0), // return 0 (falsy)
+            if_.end(), // end string
+        if_.end(), // end bool
+    if_.end(), // end number
+    fn.end(),
+);
 
 // biome-ignore format: keep if structure
-const ensureSpaceFunctionBody = [
-	// param: i32 sizeNeeded
-	...local.declare("i32"), // currentPtr
-	// currentPtr = global heap ptr
-	...global.get(0),
-	...local.set(1),
+const ensureSpaceFunctionBody = wat(
+    // param: i32 sizeNeeded
+    local.declare("i32"), // currentPtr
+    // currentPtr = global heap ptr
+    global.get(0),
+    local.set(1),
 
-	// Check if (currentPtr + sizeNeeded) > memory.size * 65536
-	...local.get(1),
-	...local.get(0),
-	...i32.add(),
+    // Check if (currentPtr + sizeNeeded) > memory.size * 65536
+    local.get(1),
+    local.get(0),
+    i32.add(),
 
-	...memory.size(),
-	...i32.const(16),
-	...i32.shl(),
+    memory.size(),
+    i32.const(16),
+    i32.shl(),
 
-	...i32.gt_u(),
-	...if_.start(),
+    i32.gt_u(),
+    if_.start(),
         // ceil(sizeNeeded / 65536)
-        ...local.get(0),
-        ...i32.const(65536 - 1),
-        ...i32.add(),
-        ...i32.const(16),
-        ...i32.shr_u(),
-        ...memory.grow(),
-        ...misc.drop(),
-	...if_.end(),
-	...fn.end(),
-];
+        local.get(0),
+        i32.const(65536 - 1),
+        i32.add(),
+        i32.const(16),
+        i32.shr_u(),
+        memory.grow(),
+        misc.drop(),
+    if_.end(),
+    fn.end(),
+);
 
 // To make this easier, everything is boxed as i32
-const boxNumberFunctionBody = [
+const boxNumberFunctionBody = wat(
 	// incoming param: f64 value
-	...local.declare("i32"), // temp_ptr
+	local.declare("i32"), // temp_ptr
 
-	...i32.const(16),
-	...fn.call(func().ensure_space),
+	i32.const(16),
+	fn.call(func().ensure_space),
 
 	// temp_ptr = heap_ptr
-	...global.get(0),
-	...local.set(1), // local[1] = temp_ptr
+	global.get(0),
+	local.set(1), // local[1] = temp_ptr
 
 	// store tag = 1 (number) at temp_ptr
-	...local.get(1),
-	...i32.const(1),
-	...i32.store(0), // offset = 0
+	local.get(1),
+	i32.const(1),
+	i32.store(0), // offset = 0
 
 	// store f64 at temp_ptr + 8
-	...local.get(1),
-	...i32.const(8),
-	...i32.add(),
-	...local.get(0), // f64 param
-	...f64.store(0), // offset = 0
+	local.get(1),
+	i32.const(8),
+	i32.add(),
+	local.get(0), // f64 param
+	f64.store(0), // offset = 0
 
 	// heap_ptr += 16
-	...global.setFromOffset(16),
+	global.setFromOffset(16),
 
 	// return temp_ptr
-	...local.get(1),
-	...fn.end(),
-];
+	local.get(1),
+	fn.end(),
+);
 
-const unboxNumberFunctionBody = [
+const unboxNumberFunctionBody = wat(
 	// incoming param: pointer to boxed value
-	...local.declare(),
-	...local.get(0),
-	...i32.const(8),
-	...i32.add(),
-	...f64.load(0), // align = 8, offset = 0
-	...fn.end(),
-];
+	local.declare(),
+	local.get(0),
+	i32.const(8),
+	i32.add(),
+	f64.load(0), // align = 8, offset = 0
+	fn.end(),
+);
 
-const boxStringFunctionBody = [
+const boxStringFunctionBody = wat(
 	// two incoming params: string offset (i32) and length (i32)
-	...local.declare("i32"), // declare temp_ptr
-	...i32.const(16),
-	...fn.call(func().ensure_space),
+	local.declare("i32"), // declare temp_ptr
+	i32.const(16),
+	fn.call(func().ensure_space),
 	// temp_ptr = heap_ptr
-	...global.get(0),
-	...local.set(2), // temp_ptr
+	global.get(0),
+	local.set(2), // temp_ptr
 
 	// store tag = 2 at (temp_ptr)
-	...local.get(2),
-	...i32.const(2),
-	...i32.store(0), // offset = 0
+	local.get(2),
+	i32.const(2),
+	i32.store(0), // offset = 0
 
 	// store offset param at (temp_ptr + 4)
-	...local.get(2),
-	...i32.const(4),
-	...i32.add(),
-	...local.get(0),
-	...i32.store(0), // offset = 0
+	local.get(2),
+	i32.const(4),
+	i32.add(),
+	local.get(0),
+	i32.store(0), // offset = 0
 
 	// store length param at (temp_ptr + 8)
-	...local.get(2),
-	...i32.const(8),
-	...i32.add(),
-	...local.get(1),
-	...i32.store(0), // offset = 0
+	local.get(2),
+	i32.const(8),
+	i32.add(),
+	local.get(1),
+	i32.store(0), // offset = 0
 
 	// heap_ptr += 16
-	...global.setFromOffset(16),
+	global.setFromOffset(16),
 
 	// return temp_ptr
-	...local.get(2),
-	...fn.end(),
-];
+	local.get(2),
+	fn.end(),
+);
 
-const boxBooleanFunctionBody = [
+const boxBooleanFunctionBody = wat(
 	// incoming param: boolean value (i32)
-	...local.declare("i32"), // temp_ptr
-	...i32.const(16),
-	...fn.call(func().ensure_space),
+	local.declare("i32"), // temp_ptr
+	i32.const(16),
+	fn.call(func().ensure_space),
 	// temp_ptr = heap_ptr
-	...global.get(0),
-	...local.set(1),
+	global.get(0),
+	local.set(1),
 
 	// store tag = 3 (boolean)
-	...local.get(1),
-	...i32.const(3),
-	...i32.store(0), // offset = 0
+	local.get(1),
+	i32.const(3),
+	i32.store(0), // offset = 0
 
 	// store boolean value at temp_ptr + 4
-	...local.get(1),
-	...i32.const(4),
-	...i32.add(),
-	...local.get(0),
-	...i32.store(0), // offset = 0
+	local.get(1),
+	i32.const(4),
+	i32.add(),
+	local.get(0),
+	i32.store(0), // offset = 0
 
 	// heap_ptr += 16
-	...global.setFromOffset(16),
+	global.setFromOffset(16),
 
 	// return temp_ptr
-	...local.get(1),
-	...fn.end(),
-];
+	local.get(1),
+	fn.end(),
+);
 
-const boxNilFunctionBody = [
+const boxNilFunctionBody = wat(
 	// no incoming params
-	...local.declare(),
-	...global.get(0),
-	...i32.const(0), // nil tag
-	...i32.store(),
-	...global.setFromOffset(16), // increment heap pointer
-	...global.get(0),
-	...fn.end(),
-];
+	local.declare(),
+	global.get(0),
+	i32.const(0), // nil tag
+	i32.store(),
+	global.setFromOffset(16), // increment heap pointer
+	global.get(0),
+	fn.end(),
+);
 
-const builtInFuncBodies: Record<string, number[]> = {
-	main: [], // main is defined later
+const builtInFuncBodies: Record<string, Uint8Array> = {
+	main: new Uint8Array(), // main is defined later
 	mod: modFunctionBody,
 	is_truthy: isTruthyFunctionBody,
 	is_string: isStringFunctionBody,
@@ -530,7 +531,7 @@ const builtInFuncBodies: Record<string, number[]> = {
 	ensure_space: ensureSpaceFunctionBody,
 };
 export let functionBodies = { ...builtInFuncBodies };
-export const addFunctionBody = (name: string, body: number[]): void => {
+export const addFunctionBody = (name: string, body: Uint8Array): void => {
 	functionBodies[name] = body;
 };
 export const resetFunctionBodies = (): void => {

--- a/src/compiler/wasm.ts
+++ b/src/compiler/wasm.ts
@@ -209,3 +209,12 @@ export const nativeBinOps = {
 	and: null,
 	or: null,
 } as const;
+
+export const wat = (
+	...params: (number | number[] | Uint8Array)[]
+): Uint8Array =>
+	new Uint8Array(
+		params.flatMap((p) =>
+			p instanceof Uint8Array ? Array.from(p) : Array.isArray(p) ? p : [p],
+		),
+	);


### PR DESCRIPTION
This refactors the wat style helpers so instead of 

```ts
return new Uint8Array([
  ...header,
  ...typeSection,
  ...importSection,
  ...funcSection,
  ...memorySection,
  ...globalSection,
  ...exportSection,
  ...codeSection,
  ...dataSection,
]);
```
I can write this
```ts
return wat(
  header,
  typeSection,
  importSection,
  funcSection,
  memorySection,
  globalSection,
  exportSection,
  codeSection,
  dataSection,
);
```